### PR TITLE
[ON HOLD] Switch to Firebase Crashlytics + Performance

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -62,4 +62,5 @@ dependencies {
     implementation 'com.android.support:multidex:1.0.3'
 }
 
+apply plugin: 'io.fabric'
 apply plugin: 'com.google.gms.google-services'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -22,6 +22,7 @@ if (flutterVersionName == null) {
 }
 
 apply plugin: 'com.android.application'
+apply plugin: 'com.google.firebase.firebase-perf'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
@@ -60,6 +61,8 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     implementation 'com.android.support:multidex:1.0.3'
+    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.9'
+    implementation 'com.google.firebase:firebase-perf:16.2.4'
 }
 
 apply plugin: 'io.fabric'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,6 +12,7 @@ buildscript {
         classpath 'com.android.tools.build:gradle:3.2.1'
         classpath 'com.google.gms:google-services:4.2.0'  // Google Services plugin
         classpath 'io.fabric.tools:gradle:1.26.1'
+        classpath 'com.google.firebase:firebase-plugins:1.1.5'
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,11 +2,16 @@ buildscript {
     repositories {
         google()
         jcenter()
+
+	    maven {
+            url 'https://maven.fabric.io/public'
+        }
     }
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.google.gms:google-services:3.2.1'  // Google Services plugin
+        classpath 'com.google.gms:google-services:4.2.0'  // Google Services plugin
+        classpath 'io.fabric.tools:gradle:1.26.1'
     }
 }
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,12 +1,9 @@
 import 'dart:io' show Platform;
 import 'package:flutter/material.dart';
 
-import 'package:catcher/core/catcher.dart';
-import 'package:catcher/catcher_plugin.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_analytics/observer.dart';
 import 'package:get_it/get_it.dart';
-import 'package:sentry/sentry.dart';
 
 import 'package:sirene/interfaces.dart';
 import 'package:sirene/pages/main/page.dart';
@@ -43,8 +40,6 @@ class App extends State<AppWidget> {
 
     if (appMode == ApplicationMode.Production) {
       l.registerSingleton<FirebaseAnalytics>(FirebaseAnalytics());
-      l.registerSingleton<SentryClient>(SentryClient(
-          dsn: 'https://04bfa4b9d5d34110a41b89e8d8c74649@sentry.io/1425391'));
       l.registerSingleton<LogWriter>(new ProductionLogWriter());
     } else {
       l.registerSingleton<FirebaseAnalytics>(DebugFirebaseAnalytics());

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_analytics/observer.dart';
+import 'package:firebase_performance/firebase_performance.dart';
 import 'package:get_it/get_it.dart';
 
 import 'package:sirene/interfaces.dart';
@@ -16,8 +17,12 @@ import 'package:sirene/services/theming.dart';
 
 class App extends State<AppWidget> {
   static GetIt locator;
+  static Map<String, Trace> traces = Map();
 
   App() {
+    traces['app_startup'] =
+        FirebasePerformance.instance.newTrace('app_startup');
+    traces['app_startup'].start();
     locator = App.setupRegistration(GetIt());
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,30 @@
-import 'package:catcher/catcher_plugin.dart';
-import 'package:sirene/services/logging.dart';
+import 'package:flutter/widgets.dart';
 
-import './app.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 
-final config = CatcherOptions(SilentReportMode(), [LoggingCatcherHandler()]);
-void main() => Catcher(AppWidget(), debugConfig: config, releaseConfig: config);
+import 'package:sirene/app.dart';
+import 'package:sirene/interfaces.dart';
+
+void main() {
+  FlutterError.onError = (details) {
+    var isDebug = false;
+    assert(isDebug = true);
+
+    if (isDebug) {
+      FlutterError.dumpErrorToConsole(details);
+    } else {
+      final user = App.locator != null
+          ? App.locator.get<LoginManager>().currentUser
+          : null;
+
+      if (user != null) {
+        Crashlytics.instance.setUserIdentifier(user.uid);
+        Crashlytics.instance.setUserEmail(user.email);
+      }
+
+      Crashlytics.instance.onError(details);
+    }
+  };
+
+  runApp(AppWidget());
+}

--- a/lib/pages/main/page.dart
+++ b/lib/pages/main/page.dart
@@ -104,7 +104,7 @@ class _MainPageState extends State<MainPage>
         PagedViewSelector(controller: controller, children: <Widget>[
       FloatingActionButton(
         child: Icon(Icons.add),
-        onPressed: () => {},
+        onPressed: () => throw Exception("die die die"),
       ),
       Container()
     ]);

--- a/lib/pages/main/phrase-list.dart
+++ b/lib/pages/main/phrase-list.dart
@@ -67,6 +67,7 @@ class _PhraseListPageState extends State<PhraseListPage>
       //final docs = await sm.allPhrasesQuery().getDocuments();
       //setState(() =>
       //   phrases = docs.documents.map((x) => Phrase.fromDocument(x)).toList());
+      App.traces['app_startup'].stop();
       sm.getPhrases().listen((xs) {
         debug("Phrase update! ${xs.length} items");
         setState(() => phrases = xs);

--- a/lib/services/debug-analytics.dart
+++ b/lib/services/debug-analytics.dart
@@ -322,7 +322,7 @@ class DebugFirebaseAnalytics implements FirebaseAnalytics {
   /// has logged in.
   ///
   /// See: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event.html#LOGIN
-  Future<void> logLogin() {
+  Future<void> logLogin({String loginMethod}) {
     return logEvent(name: 'login');
   }
 

--- a/lib/services/logging.dart
+++ b/lib/services/logging.dart
@@ -36,18 +36,6 @@ class DebugLogWriter implements LogWriter {
   }
 }
 
-class _LogMessage {
-  _LogMessage({this.message, this.extras}) {
-    time = DateTime.now().millisecondsSinceEpoch;
-  }
-
-  int time;
-  final String message;
-  final Map<String, dynamic> extras;
-}
-
-const kMaxBufferSize = 16;
-
 class ProductionLogWriter implements LogWriter {
   @override
   void log(String message, {bool isDebug, Map<String, dynamic> extras}) {

--- a/lib/services/logging.dart
+++ b/lib/services/logging.dart
@@ -1,9 +1,8 @@
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
 
-import 'package:catcher/catcher_plugin.dart';
 import 'package:device_info/device_info.dart';
 import 'package:package_info/package_info.dart';
-import 'package:sentry/sentry.dart' as sentry;
 
 import 'package:sirene/app.dart';
 import 'package:sirene/interfaces.dart';
@@ -50,38 +49,11 @@ class _LogMessage {
 const kMaxBufferSize = 16;
 
 class ProductionLogWriter implements LogWriter {
-  var _ringBuffer = <_LogMessage>[];
-  PackageInfo _packageInfo;
-  AndroidDeviceInfo _androidDeviceInfo;
-  IosDeviceInfo _iosDeviceInfo;
-
-  ProductionLogWriter() {
-    final dip = DeviceInfoPlugin();
-    if (defaultTargetPlatform == TargetPlatform.iOS) {
-      dip.iosInfo.then((di) => _iosDeviceInfo = di).catchError((e, st) {
-        debugPrint("Couldn't get device info! $e\n$st");
-      });
-    } else {
-      dip.androidInfo.then((di) => _androidDeviceInfo = di).catchError((e, st) {
-        debugPrint("Couldn't get device info! $e\n$st");
-      });
-    }
-
-    PackageInfo.fromPlatform()
-        .then((pi) => _packageInfo = pi)
-        .catchError((e, st) {
-      debugPrint("Couldn't get package info! $e\n$st");
-    });
-  }
-
   @override
   void log(String message, {bool isDebug, Map<String, dynamic> extras}) {
     if (isDebug) return;
 
-    _ringBuffer.add(_LogMessage(message: message, extras: extras));
-    while (_ringBuffer.length > kMaxBufferSize) {
-      _ringBuffer.removeAt(0);
-    }
+    Crashlytics.instance.log(message);
   }
 
   @override
@@ -89,43 +61,14 @@ class ProductionLogWriter implements LogWriter {
       {String message, Map<String, dynamic> extras}) {
     extras ??= Map();
     final user = App.locator.get<LoginManager>().currentUser;
-    var deviceFingerprint = '';
-    var device = '';
-    var os = '';
 
-    if (_androidDeviceInfo != null) {
-      extras.addAll(androidToMap(_androidDeviceInfo));
-      deviceFingerprint = _androidDeviceInfo.fingerprint;
-      device = '${_androidDeviceInfo.manufacturer} ${_androidDeviceInfo.model}';
-      os = '${_androidDeviceInfo.version.sdkInt}';
+    if (user != null) {
+      Crashlytics.instance.setUserIdentifier(user.uid);
+      Crashlytics.instance.setUserEmail(user.email);
     }
 
-    if (_iosDeviceInfo != null) {
-      extras.addAll(iosToMap(_iosDeviceInfo));
-      deviceFingerprint = _iosDeviceInfo.utsname.machine;
-      device = _iosDeviceInfo.localizedModel;
-      os = _iosDeviceInfo.systemVersion;
-    }
-
-    // TODO: Fork flutter/sentry to support breadcrumbs
-    App.locator.get<sentry.SentryClient>().capture(
-        event: sentry.Event(
-            exception: ex,
-            stackTrace: st,
-            extra: extras,
-            message: message,
-            tags: {
-              "device": device,
-              "deviceFingerprint": deviceFingerprint,
-              "os": os,
-            },
-            userContext: sentry.User(email: user.email, id: user.uid),
-            release: _packageInfo.version));
-
-    App.analytics.logEvent(name: 'app_error', parameters: {
-      "message": message ?? '',
-      "error": ex.toString(),
-    });
+    Crashlytics.instance.onError(
+        FlutterErrorDetails(exception: ex, stack: st, context: message));
   }
 }
 
@@ -174,67 +117,4 @@ mixin LoggerMixin {
       if (rethrowIt) rethrow;
     }
   }
-}
-
-class LoggingCatcherHandler with LoggerMixin implements ReportHandler {
-  @override
-  Future<bool> handle(Report report) async {
-    logError(report.error, report.stackTrace, extras: report.deviceParameters);
-    return true;
-  }
-}
-
-void setMapValue(Map<String, dynamic> map, String key, dynamic value) {
-  map[key] = value;
-}
-
-void setMapValueIfNotNull(Map<String, dynamic> map, String key, dynamic value) {
-  if (value != null) map[key] = value;
-}
-
-List<T> codeIterable<T>(Iterable values, T callback(value)) =>
-    values?.map<T>(callback)?.toList();
-
-Map<String, dynamic> androidToMap(AndroidDeviceInfo model) {
-  if (model == null) return null;
-  Map<String, dynamic> ret = <String, dynamic>{};
-  setMapValue(ret, 'board', model.board);
-  setMapValue(ret, 'bootloader', model.bootloader);
-  setMapValue(ret, 'brand', model.brand);
-  setMapValue(ret, 'device', model.device);
-  setMapValue(ret, 'display', model.display);
-  setMapValue(ret, 'fingerprint', model.fingerprint);
-  setMapValue(ret, 'hardware', model.hardware);
-  setMapValue(ret, 'host', model.host);
-  setMapValue(ret, 'id', model.id);
-  setMapValue(ret, 'manufacturer', model.manufacturer);
-  setMapValue(ret, 'model', model.model);
-  setMapValue(ret, 'product', model.product);
-  setMapValue(ret, 'supported32BitAbis',
-      codeIterable(model.supported32BitAbis, (val) => val as String));
-  setMapValue(ret, 'supported64BitAbis',
-      codeIterable(model.supported64BitAbis, (val) => val as String));
-  setMapValue(ret, 'supportedAbis',
-      codeIterable(model.supportedAbis, (val) => val as String));
-  setMapValue(ret, 'tags', model.tags);
-  setMapValue(ret, 'type', model.type);
-  setMapValue(ret, 'isPhysicalDevice', model.isPhysicalDevice);
-  setMapValue(ret, 'androidId', model.androidId);
-
-  ret['version'] =
-      "Android ${model.version.sdkInt} ${model.version.release} - ${model.version.incremental} Patch Level ${model.version.securityPatch}";
-  return ret;
-}
-
-Map<String, dynamic> iosToMap(IosDeviceInfo model) {
-  if (model == null) return null;
-  Map<String, dynamic> ret = <String, dynamic>{};
-  setMapValue(ret, 'name', model.name);
-  setMapValue(ret, 'systemName', model.systemName);
-  setMapValue(ret, 'systemVersion', model.systemVersion);
-  setMapValue(ret, 'model', model.model);
-  setMapValue(ret, 'localizedModel', model.localizedModel);
-  setMapValue(ret, 'identifierForVendor', model.identifierForVendor);
-  setMapValue(ret, 'isPhysicalDevice', model.isPhysicalDevice);
-  return ret;
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -183,6 +183,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.2"
+  firebase_performance:
+    dependency: "direct main"
+    description:
+      name: firebase_performance
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0+4"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -85,13 +85,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.3.2"
-  catcher:
-    dependency: "direct main"
-    description:
-      name: catcher
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.4"
   charcode:
     dependency: transitive
     description:
@@ -127,13 +120,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
-  cookie_jar:
-    dependency: transitive
-    description:
-      name: cookie_jar
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.0"
   crypto:
     dependency: transitive
     description:
@@ -155,13 +141,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.2"
-  dart2_constant:
-    dependency: transitive
-    description:
-      name: dart2_constant
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2+dart2"
   dart_style:
     dependency: transitive
     description:
@@ -176,34 +155,34 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.0+1"
-  dio:
-    dependency: transitive
-    description:
-      name: dio
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.0"
   firebase_analytics:
     dependency: "direct main"
     description:
       name: firebase_analytics
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.1.0"
   firebase_auth:
     dependency: "direct main"
     description:
       name: firebase_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.1+4"
+    version: "0.8.3"
   firebase_core:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.3.1+1"
+  firebase_crashlytics:
+    dependency: "direct main"
+    description:
+      name: firebase_crashlytics
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.2"
   fixnum:
     dependency: transitive
     description:
@@ -216,20 +195,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_local_notifications:
-    dependency: transitive
-    description:
-      name: flutter_local_notifications
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.2"
-  flutter_mailer:
-    dependency: transitive
-    description:
-      name: flutter_mailer
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.4.0+1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -242,13 +207,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.4"
-  fluttertoast:
-    dependency: transitive
-    description:
-      name: fluttertoast
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.3"
   front_end:
     dependency: transitive
     description:
@@ -312,13 +270,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.3"
-  intl:
-    dependency: transitive
-    description:
-      name: intl
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.15.8"
   io:
     dependency: transitive
     description:
@@ -368,13 +319,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.11.3+2"
-  mailer:
-    dependency: transitive
-    description:
-      name: mailer
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.2.1"
   matcher:
     dependency: transitive
     description:
@@ -431,13 +375,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.0"
-  platform:
-    dependency: transitive
-    description:
-      name: platform
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.2.0"
   plugin:
     dependency: transitive
     description:
@@ -494,27 +431,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.20.0"
-  sentry:
-    dependency: "direct main"
-    description:
-      name: sentry
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.2.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.4+1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2+4"
+    version: "0.2.2+5"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -590,13 +520,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.6"
-  usage:
-    dependency: transitive
-    description:
-      name: usage
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.4.1"
   utf:
     dependency: transitive
     description:
@@ -624,7 +547,7 @@ packages:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.11"
+    version: "1.0.12"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,21 +15,20 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
+  firebase_core: ^0.3.1+1
   device_info: ^0.4.0+1
-  catcher: ^0.1.4
-  sentry: ^2.2.0
+  firebase_crashlytics: ^0.0.2
   package_info: ^0.4.0+2
   cupertino_icons: ^0.1.2
   jaguar_serializer: ^2.2.12
-  cloud_firestore: ^0.9.0
-  firebase_auth: ^0.8.0
+  cloud_firestore: ^0.9.7
+  firebase_auth: ^0.8.3
   google_sign_in: ^4.0.1
   rxdart: ^0.20.0
   rx_command: ^4.1.0
   get_it: ^1.0.2
   flutter_tts: ^0.2.4
-  firebase_analytics: ^2.0.3
+  firebase_analytics: ^2.1.0
 
 dev_dependencies:
   build_runner:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   get_it: ^1.0.2
   flutter_tts: ^0.2.4
   firebase_analytics: ^2.1.0
+  firebase_performance: ^0.1.0+4
 
 dev_dependencies:
   build_runner:


### PR DESCRIPTION
Switch to Crashlytics and Firebase Performance instead of Sentry, since we get native crash reporting for free

## TODO:

- [x] Wait for https://github.com/flutter/plugins/pull/1418 to get merged
- [ ] Wait for https://github.com/flutter/flutter/issues/30147 to get fixed
- [x] Figure out why we can't get past the setup screen on Firebase Performance metrics despite logging them