### PR TITLE
UX improvements for Speak Pane

### DIFF
--- a/lib/pages/main/speak-pane.dart
+++ b/lib/pages/main/speak-pane.dart
@@ -82,7 +82,20 @@ class _SpeakPaneState extends State<SpeakPane> with LoggerMixin {
               child: TextField(
             controller: toSpeak,
             focusNode: textBoxFocus,
+            autofocus: true,
+            expands: true,
+            minLines: null,
+            maxLines: null,
           )),
+          Padding(
+            padding: EdgeInsets.symmetric(vertical: 16),
+            child: RaisedButton(
+                child: Text("Clear"),
+                onPressed: () {
+                  toSpeak.clear();
+                  FocusScope.of(context).requestFocus(textBoxFocus);
+                }),
+          ),
           Flex(
               direction: Axis.horizontal,
               crossAxisAlignment: CrossAxisAlignment.center,


### PR DESCRIPTION
Improve some of the usability of the Speak pane:

* Add a clear button to clear the text box and focus it
* Make the custom phrase list also be a quicksearch, so you can just stay on this page all the time