### PR TITLE
Language detection improvements

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -41,10 +41,6 @@ android {
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
-
-        ndk {
-            abiFilters 'armeabi-v7a'
-        }
     }
 
     buildTypes {
@@ -52,6 +48,10 @@ android {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
+
+            ndk {
+                abiFilters 'armeabi-v7a'
+            }
         }
     }
 }

--- a/lib/interfaces.dart
+++ b/lib/interfaces.dart
@@ -30,7 +30,7 @@ abstract class StorageManager {
 
   Future<void> deletePhrase(Phrase phrase, {UserInfo forUser});
 
-  Future<void> presentPhrase(Phrase phrase, {UserInfo forUser});
+  Future<void> savePresentedPhrase(Phrase phrase, {UserInfo forUser});
 
   static isCustomPhraseExpired(DateTime forDate) {
     final expiration = forDate.add(Duration(hours: 1));
@@ -38,6 +38,8 @@ abstract class StorageManager {
   }
 
   Future<void> loadDefaultSavedPhrases({UserInfo forUser});
+
+  Future<String> getRecentFallbackLanguage({UserInfo forUser});
 }
 
 abstract class FirebaseDocument {
@@ -56,6 +58,8 @@ class User implements FirebaseDocument {
   String lastCustomPhrase;
   DateTime lastCustomPhraseCreatedOn;
 
+  List<String> recentlyUsedLanguages;
+
   static User fromDocument(DocumentSnapshot ds) {
     return userSerializer.fromDocument(ds);
   }
@@ -66,6 +70,7 @@ class User implements FirebaseDocument {
 }
 
 const kMaxRecentUsagesCount = 8;
+const kMaxRecentLanguageCount = 4;
 
 class Phrase implements FirebaseDocument {
   Phrase({this.text, this.spokenText, this.isReply});
@@ -76,6 +81,7 @@ class Phrase implements FirebaseDocument {
   String text;
   String spokenText;
   bool isReply;
+  String detectedLanguage;
 
   List<DateTime> recentUsages;
   int usageCount;

--- a/lib/interfaces.dart
+++ b/lib/interfaces.dart
@@ -70,7 +70,10 @@ class User implements FirebaseDocument {
 }
 
 const kMaxRecentUsagesCount = 8;
-const kMaxRecentLanguageCount = 4;
+
+// NB: We don't want this to be too long, or else we'll possibly end up using a
+// language that was frequent but a long time ago
+const kMaxRecentLanguageCount = 3;
 
 class Phrase implements FirebaseDocument {
   Phrase({this.text, this.spokenText, this.isReply});

--- a/lib/interfaces.jser.dart
+++ b/lib/interfaces.jser.dart
@@ -51,6 +51,8 @@ abstract class _$UserJsonSerializer implements Serializer<User> {
     setMapValue(ret, 'lastCustomPhrase', model.lastCustomPhrase);
     setMapValue(ret, 'lastCustomPhraseCreatedOn',
         dateTimeUtcProcessor.serialize(model.lastCustomPhraseCreatedOn));
+    setMapValue(ret, 'recentlyUsedLanguages',
+        codeIterable(model.recentlyUsedLanguages, (val) => val as String));
     return ret;
   }
 
@@ -63,6 +65,8 @@ abstract class _$UserJsonSerializer implements Serializer<User> {
     obj.lastCustomPhrase = map['lastCustomPhrase'] as String;
     obj.lastCustomPhraseCreatedOn = dateTimeUtcProcessor
         .deserialize(map['lastCustomPhraseCreatedOn'] as String);
+    obj.recentlyUsedLanguages = codeIterable<String>(
+        map['recentlyUsedLanguages'] as Iterable, (val) => val as String);
     return obj;
   }
 }

--- a/lib/interfaces.jser.dart
+++ b/lib/interfaces.jser.dart
@@ -14,6 +14,7 @@ abstract class _$PhraseJsonSerializer implements Serializer<Phrase> {
     setMapValue(ret, 'text', model.text);
     setMapValue(ret, 'spokenText', model.spokenText);
     setMapValue(ret, 'isReply', model.isReply);
+    setMapValue(ret, 'detectedLanguage', model.detectedLanguage);
     setMapValue(
         ret,
         'recentUsages',
@@ -32,6 +33,7 @@ abstract class _$PhraseJsonSerializer implements Serializer<Phrase> {
     obj.text = map['text'] as String;
     obj.spokenText = map['spokenText'] as String;
     obj.isReply = map['isReply'] as bool;
+    obj.detectedLanguage = map['detectedLanguage'] as String;
     obj.recentUsages = codeIterable<DateTime>(map['recentUsages'] as Iterable,
         (val) => dateTimeUtcProcessor.deserialize(val as String));
     obj.usageCount = map['usageCount'] as int;


### PR DESCRIPTION
This PR fixes the bug where if you were having a conversation with someone and you responded with a date ("1/1/1979" or sth), you'd suddenly change accents. Now when we don't know the language of a phrase, we guess that we should probably respond the way we just were responding.

We also save off information about the detected language into the phrase itself, so we don't have to kick the ML engine so often